### PR TITLE
#407clear ontvanger locatie

### DIFF
--- a/src/views/RegisterPackage.vue
+++ b/src/views/RegisterPackage.vue
@@ -20,6 +20,7 @@
             <CBSearchSuggestions
               :options="receivers"
               label="Ontvanger:"
+              :selectedOption="fpacker.RecieverId"
               @selectChanged="receiverChanged"
               :valid="receiverValid"
             />
@@ -38,6 +39,7 @@
             <CBSearchSuggestions
               :options="rooms"
               label="Afhaalpunt:"
+              :selectedOption="fpackage.CollectionPointId"
               @selectChanged="collectionPointChanged"
               :valid="collectionPointValid"
             />

--- a/src/views/RegisterPackage.vue
+++ b/src/views/RegisterPackage.vue
@@ -20,7 +20,7 @@
             <CBSearchSuggestions
               :options="receivers"
               label="Ontvanger:"
-              :selectedOption="fpacker.RecieverId"
+              :selectedOption="getReceiver()"
               @selectChanged="receiverChanged"
               :valid="receiverValid"
             />
@@ -39,7 +39,7 @@
             <CBSearchSuggestions
               :options="rooms"
               label="Afhaalpunt:"
-              :selectedOption="fpackage.CollectionPointId"
+              :selectedOption="getRoom()"
               @selectChanged="collectionPointChanged"
               :valid="collectionPointValid"
             />
@@ -92,6 +92,8 @@ import SelectOption from "@/classes/helpers/SelectOption";
 import { getCurrentInstance, watch } from "@vue/runtime-core";
 import { AxiosError } from "axios";
 import LoadingIcon from "@/components/standardUi/LoadingIcon.vue";
+import Building from "@/classes/Building";
+import Address from "@/classes/Address";
 
 @Options({
   components: {
@@ -192,6 +194,19 @@ export default class RegisterPackage extends Vue {
         this.emitter.emit("err", err);
         this.loadPostRequest = false;
       });
+  }
+
+  getReceiver(){
+    if(this.receiver){
+          return this.receiver;
+    }
+
+  }
+
+  getRoom(){
+    if(this.room){
+      return this.room;
+    }
   }
 
   receiverChanged(input: SelectOption): void {


### PR DESCRIPTION
Ik heb hem getest, de cbs select houden hun waarden als men naar vorige gaat, dit doe ik door hun selectedoptions een methode callen die kijk of de waarde die je normaal set defined is en ze returnt als ze er zijn, doe je dat niet dan crasht hij als ze leeg zijn, dit werkt ook als je ze aanpast en modal hopt.